### PR TITLE
feat(#9) : Contest 도메인 구현

### DIFF
--- a/src/main/java/com/example/devcrew/domain/contest/entity/Contest.java
+++ b/src/main/java/com/example/devcrew/domain/contest/entity/Contest.java
@@ -1,0 +1,61 @@
+package com.example.devcrew.domain.contest.entity;
+
+import com.example.devcrew.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Contest extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String posterUrl;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(length = 10)
+    private String organization;
+
+    @Column(length = 20)
+    private String participantTarget;
+
+    @Column(length = 20)
+    private String award;
+
+    private String homepageUrl;
+
+    private LocalDateTime startDate;
+
+    private LocalDateTime endDate;
+
+    @Enumerated(EnumType.STRING)
+    private Sector sector;
+
+    @Column(length = 20)
+    private String benefits;
+
+    @Column(length = 20)
+    private String plusBenefits;
+
+    @Lob
+    private String description;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "companyMember_id")
+//    private CompanyMember companyMember;
+//
+//    @OneToMany(mappedBy = "contest", cascade = CascadeType.ALL)
+//    private List<Team> teamList = new ArrayList<>();
+}

--- a/src/main/java/com/example/devcrew/domain/contest/entity/Sector.java
+++ b/src/main/java/com/example/devcrew/domain/contest/entity/Sector.java
@@ -1,0 +1,17 @@
+package com.example.devcrew.domain.contest.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Sector {
+    STARTUP("창업"),
+    AI("생성형 AI"),
+    PLATFORM("플랫폼"),
+    DATAALALYSIS("데이터분석"),
+    GAME("게임"),
+    OTHER("기타");
+
+    private final String sector;
+}


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- #9 

### ⚡️ 작업동기

- 공모전 도메인 구현

### 🔑 주요 변경사항

- Contest 엔터티 추가

### 💡 관련 이슈

- 기업회원은 아직 구현 안함
- 관계 설정은 주석처리함
