### PR TITLE
Feat(#43) : 공모전 안에 매칭 팀 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/devcrew/domain/contest/api/ContestRestController.java
+++ b/src/main/java/com/example/devcrew/domain/contest/api/ContestRestController.java
@@ -2,10 +2,7 @@ package com.example.devcrew.domain.contest.api;
 
 import com.example.devcrew.domain.contest.converter.ContestConverter;
 import com.example.devcrew.domain.contest.dto.request.CreateContestRequestDTO;
-import com.example.devcrew.domain.contest.dto.response.CreateContestResponseDTO;
-import com.example.devcrew.domain.contest.dto.response.GetContestDetailResponseDTO;
-import com.example.devcrew.domain.contest.dto.response.GetContestListResponseDTO;
-import com.example.devcrew.domain.contest.dto.response.GetContestOneResponseDTO;
+import com.example.devcrew.domain.contest.dto.response.*;
 import com.example.devcrew.domain.contest.entity.Contest;
 import com.example.devcrew.domain.contest.entity.Sector;
 import com.example.devcrew.domain.contest.service.ContestCommandService;
@@ -71,6 +68,17 @@ public class ContestRestController {
     public ResponseEntity<GetContestDetailResponseDTO> getContestDetail(@PathVariable Long contestId) {
         GetContestDetailResponseDTO contestDetail = contestQueryService.findContestDetailById(contestId);
         return new ResponseEntity<>(contestDetail, HttpStatus.OK);
+    }
+
+
+    @GetMapping("/{contestId}/teams")
+    @Operation(summary = "공모전 매칭 팀 정보 조회", description = "한 공모전에서 매칭 중인 팀 정보를 조회할 수 있습니다.")
+    @Parameters({
+            @Parameter(name = "contestId", description = "공모전의 아이디, PathVariable 입니다."),
+    })
+    public ResponseEntity<GetTeamInfoListResponseDTO> getTeamsInContest(@PathVariable Long contestId) {
+        GetTeamInfoListResponseDTO teamInfoList = contestQueryService.findTeamsInContest(contestId);
+        return new ResponseEntity<>(teamInfoList, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/example/devcrew/domain/contest/converter/ContestConverter.java
+++ b/src/main/java/com/example/devcrew/domain/contest/converter/ContestConverter.java
@@ -4,15 +4,19 @@ import com.example.devcrew.domain.contest.dto.request.CreateContestRequestDTO;
 import com.example.devcrew.domain.contest.dto.response.CreateContestResponseDTO;
 import com.example.devcrew.domain.contest.dto.response.GetContestDetailResponseDTO;
 import com.example.devcrew.domain.contest.dto.response.GetContestOneResponseDTO;
+import com.example.devcrew.domain.contest.dto.response.GetTeamInfoOneResponseDTO;
 import com.example.devcrew.domain.contest.entity.Contest;
 import com.example.devcrew.domain.contest.entity.Sector;
 import com.example.devcrew.domain.member.entity.CompanyMember;
 import com.example.devcrew.domain.member.entity.Member;
+import com.example.devcrew.domain.team.entity.Team;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ContestConverter {
 
@@ -49,6 +53,7 @@ public class ContestConverter {
         String endDate = extractEndDate(contest.getAcceptancePeriod());
 
         return GetContestOneResponseDTO.builder()
+                .id(contest.getId())
                 .posterUrl(contest.getPosterUrl())
                 .title(contest.getTitle())
                 .sector(contest.getSector().getSector())
@@ -89,6 +94,7 @@ public class ContestConverter {
 
 
         return GetContestDetailResponseDTO.builder()
+                .id(contest.getId())
                 .poster(contest.getPosterUrl())
                 .title(contest.getTitle())
                 .organization(contest.getOrganization())
@@ -120,4 +126,23 @@ public class ContestConverter {
         }
         return "담당자 번호를 찾을 수 없습니다.";
     }
+
+
+
+    public static List<GetTeamInfoOneResponseDTO> toGetTeamInfoOneResponseDTOList(List<Team> teams) {
+        return teams.stream()
+                .map(ContestConverter::toGetTeamInfoOneResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+
+    public static GetTeamInfoOneResponseDTO toGetTeamInfoOneResponseDTO(Team team) {
+        return GetTeamInfoOneResponseDTO.builder()
+                .teamId(team.getId())
+                .teamName(team.getName())
+                .planUrl(team.getPlanUrl())
+                .teamEmail(team.getMember().getEmail())
+                .build();
+    }
+
 }

--- a/src/main/java/com/example/devcrew/domain/contest/dto/response/GetContestDetailResponseDTO.java
+++ b/src/main/java/com/example/devcrew/domain/contest/dto/response/GetContestDetailResponseDTO.java
@@ -7,6 +7,7 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetContestDetailResponseDTO {
+    private Long id;
 
     private String poster;
 

--- a/src/main/java/com/example/devcrew/domain/contest/dto/response/GetContestOneResponseDTO.java
+++ b/src/main/java/com/example/devcrew/domain/contest/dto/response/GetContestOneResponseDTO.java
@@ -8,6 +8,7 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetContestOneResponseDTO {
+    private Long id;
 
     private String posterUrl;
 

--- a/src/main/java/com/example/devcrew/domain/contest/dto/response/GetTeamInfoListResponseDTO.java
+++ b/src/main/java/com/example/devcrew/domain/contest/dto/response/GetTeamInfoListResponseDTO.java
@@ -1,0 +1,14 @@
+package com.example.devcrew.domain.contest.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetTeamInfoListResponseDTO {
+    private Long contestId;
+    private List<GetTeamInfoOneResponseDTO> teamInfoList;
+}

--- a/src/main/java/com/example/devcrew/domain/contest/dto/response/GetTeamInfoOneResponseDTO.java
+++ b/src/main/java/com/example/devcrew/domain/contest/dto/response/GetTeamInfoOneResponseDTO.java
@@ -1,0 +1,15 @@
+package com.example.devcrew.domain.contest.dto.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetTeamInfoOneResponseDTO {
+
+    private Long teamId;
+    private String teamName;
+    private String planUrl;
+    private String teamEmail;
+}

--- a/src/main/java/com/example/devcrew/domain/contest/service/ContestQueryService.java
+++ b/src/main/java/com/example/devcrew/domain/contest/service/ContestQueryService.java
@@ -1,13 +1,10 @@
 package com.example.devcrew.domain.contest.service;
 
-import com.example.devcrew.domain.contest.dto.response.GetContestDetailResponseDTO;
-import com.example.devcrew.domain.contest.dto.response.GetContestListResponseDTO;
-import com.example.devcrew.domain.contest.dto.response.GetContestOneResponseDTO;
+import com.example.devcrew.domain.contest.dto.response.*;
 import com.example.devcrew.domain.contest.entity.Sector;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
 
 public interface ContestQueryService {
     public Page<GetContestOneResponseDTO> findAllContests(Pageable pageable);
@@ -17,4 +14,6 @@ public interface ContestQueryService {
     public GetContestDetailResponseDTO findContestDetailById(Long contestId);
 
     public GetContestListResponseDTO getContests(Sector sector, int page, int size, String sort, String order);
+
+    public GetTeamInfoListResponseDTO findTeamsInContest(Long contestId);
     }

--- a/src/main/java/com/example/devcrew/domain/contest/service/ContestQueryServiceImpl.java
+++ b/src/main/java/com/example/devcrew/domain/contest/service/ContestQueryServiceImpl.java
@@ -1,14 +1,15 @@
 package com.example.devcrew.domain.contest.service;
 
 import com.example.devcrew.domain.contest.converter.ContestConverter;
-import com.example.devcrew.domain.contest.dto.response.GetContestDetailResponseDTO;
-import com.example.devcrew.domain.contest.dto.response.GetContestListResponseDTO;
-import com.example.devcrew.domain.contest.dto.response.GetContestOneResponseDTO;
+import com.example.devcrew.domain.contest.dto.response.*;
 import com.example.devcrew.domain.contest.entity.Contest;
 import com.example.devcrew.domain.contest.entity.Sector;
 import com.example.devcrew.domain.contest.repository.ContestRepository;
 import com.example.devcrew.domain.member.entity.Member;
 import com.example.devcrew.domain.member.exception.MemberNotFoundException;
+import com.example.devcrew.domain.team.entity.Team;
+import com.example.devcrew.domain.team.exception.TeamNotFoundException;
+import com.example.devcrew.domain.team.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -28,6 +29,7 @@ import java.util.stream.Collectors;
 public class ContestQueryServiceImpl implements ContestQueryService{
 
     private final ContestRepository contestRepository;
+    private final TeamRepository teamRepository;
 
     // 공모전 전체 조회
     @Override
@@ -91,4 +93,25 @@ public class ContestQueryServiceImpl implements ContestQueryService{
         System.out.println(name);
         return ContestConverter.toGetContestDetailResponseDTO(contest, member);
     }
+
+
+    // 공모전 안에 매칭중인 팀 조회
+    @Override
+    public GetTeamInfoListResponseDTO findTeamsInContest(Long contestId){
+        Contest contest = contestRepository.findById(contestId)
+                .orElseThrow(ContestNotFoundException::new);
+
+        List<Team> teams = teamRepository.findByContest(contest);
+        if (teams.isEmpty()) {
+            throw new TeamNotFoundException();
+        }
+
+        List<GetTeamInfoOneResponseDTO> teamInfoList = ContestConverter.toGetTeamInfoOneResponseDTOList(teams);
+
+        return GetTeamInfoListResponseDTO.builder()
+                .contestId(contest.getId())
+                .teamInfoList(teamInfoList)
+                .build();
+    }
+
 }

--- a/src/main/java/com/example/devcrew/domain/contest/service/ContestQueryServiceImpl.java
+++ b/src/main/java/com/example/devcrew/domain/contest/service/ContestQueryServiceImpl.java
@@ -89,8 +89,7 @@ public class ContestQueryServiceImpl implements ContestQueryService{
         if (member == null) {
             throw new MemberNotFoundException();
         }
-        String name = member.getCompanyMember().getCeoName();
-        System.out.println(name);
+
         return ContestConverter.toGetContestDetailResponseDTO(contest, member);
     }
 

--- a/src/main/java/com/example/devcrew/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/example/devcrew/domain/team/repository/TeamRepository.java
@@ -1,12 +1,16 @@
 package com.example.devcrew.domain.team.repository;
 
+import com.example.devcrew.domain.contest.entity.Contest;
 import com.example.devcrew.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface TeamRepository extends JpaRepository<Team, Long> {
     Optional<Team> findByIdAndPassword(Long id, String password);
+
+    List<Team> findByContest(Contest contest);
 }


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- #43 

### ⚡️ 작업동기

- 공모전 상세 페이지 하단에 있는 매칭 팀 정보 조회

### 🔑 주요 변경사항

- 팀 정보 조회이긴 하지만 한 공모전 안에 존재하는 매칭 팀을 조회하는 것이라 생각해서 일단 공모전 부분에 구현했습니다.

### 💡 관련 이슈

- 관련 이슈를 입력해주세요.
