### PR TITLE
Feat/#46 공모전 정보 조회 구현

### DIFF
--- a/src/main/java/com/example/devcrew/domain/team/api/TeamController.java
+++ b/src/main/java/com/example/devcrew/domain/team/api/TeamController.java
@@ -1,5 +1,7 @@
 package com.example.devcrew.domain.team.api;
 
+import com.example.devcrew.domain.contest.dto.response.GetContestDetailResponseDTO;
+import com.example.devcrew.domain.contest.service.ContestQueryService;
 import com.example.devcrew.domain.team.dto.request.CreateTeamRequestDTO;
 import com.example.devcrew.domain.team.entity.Team;
 import com.example.devcrew.domain.team.service.TeamService;
@@ -7,8 +9,11 @@ import com.example.devcrew.domain.team.dto.request.ApplyTeamRequestDTO;
 import com.example.devcrew.domain.team.dto.response.GetMemberInfoResponseDTO;
 import com.example.devcrew.domain.team.entity.TeamMatching;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class TeamController {
 
     private final TeamService teamService;
+    private final ContestQueryService contestQueryService;
 
     @GetMapping("/create")
     @Operation(summary = "팀 구성 기능에서 멤버 정보 조회", description = "팀 생성 시 해당 멤버의 이름과 전화번호 반환(자동완성기능).")
@@ -26,14 +32,14 @@ public class TeamController {
     }
 
     @PostMapping("/create")
-    @Operation(summary = "Create a new team")
+    @Operation(summary = "팀 구성하기")
     public Team createTeamsByContestAndMember(@RequestBody @Valid CreateTeamRequestDTO createTeamRequestDTO) {
         return teamService.createTeamsByContestAndMember(createTeamRequestDTO);
     }
 
     @GetMapping("/apply")
-    @Operation(summary = "팀 신청 기능에서 멤버 정보 조회", description = "팀원 신청서 작성 시 해당 멤버의 이름과 전화번호를 반환합니다.(자동완성기능)")
-    public GetMemberInfoResponseDTO getMemberInfo() {
+    @Operation(summary = "팀 신청 기능에서 멤버 정보 조회", description = "팀원 신청서 작성 시 해당 멤버의 이름과 전화번호를 반환(자동완성기능)")
+    public GetMemberInfoResponseDTO getMemberInfoForApply() {
         return teamService.GetMemberInfo();
     }
 
@@ -41,5 +47,24 @@ public class TeamController {
     @Operation(summary = "팀 신청하기")
     public TeamMatching applyTeam(@RequestBody @Valid ApplyTeamRequestDTO applyTeamRequestDTO) {
         return teamService.applyToTeam(applyTeamRequestDTO);
+    }
+
+
+    @GetMapping("/apply/{contestId}")
+    @Operation(summary = "공모전 상세 조회", description =  "팀 신청 페이지 상단에 표시할 공모전 상세 정보 조회")
+    @Parameters({
+            @Parameter(name = "contestId", description = "공모전의 아이디, PathVariable 입니다."),
+    })
+    public GetContestDetailResponseDTO getContestDetailForApply(@PathVariable Long contestId) {
+        return contestQueryService.findContestDetailById(contestId);
+    }
+
+    @GetMapping("/create/{contestId}")
+    @Operation(summary = "공모전 상세 조회", description = "팀 구성 페이지 상단에 표시할 공모전 상세 정보 조회")
+    @Parameters({
+            @Parameter(name = "contestId", description = "공모전의 아이디, PathVariable 입니다."),
+    })
+    public GetContestDetailResponseDTO getContestDetailForCreate(@PathVariable Long contestId) {
+        return contestQueryService.findContestDetailById(contestId);
     }
 }

--- a/src/main/java/com/example/devcrew/domain/team/api/TeamController.java
+++ b/src/main/java/com/example/devcrew/domain/team/api/TeamController.java
@@ -1,5 +1,7 @@
 package com.example.devcrew.domain.team.api;
 
+import com.example.devcrew.domain.team.dto.request.CreateTeamRequestDTO;
+import com.example.devcrew.domain.team.entity.Team;
 import com.example.devcrew.domain.team.service.TeamService;
 import com.example.devcrew.domain.team.dto.request.ApplyTeamRequestDTO;
 import com.example.devcrew.domain.team.dto.response.GetMemberInfoResponseDTO;
@@ -17,51 +19,27 @@ public class TeamController {
 
     private final TeamService teamService;
 
-//####### 아직 상단에 뜨는 관련된 공모전 상세 정보는 구현하지 않았음 ######
     @GetMapping("/create")
     @Operation(summary = "팀 구성 기능에서 멤버 정보 조회", description = "팀 생성 시 해당 멤버의 이름과 전화번호 반환(자동완성기능).")
-    public ResponseEntity<GetMemberInfoResponseDTO> getMemberInfoForCreate() {
-        GetMemberInfoResponseDTO response = teamService.GetMemberInfo();
-        return ResponseEntity.ok(response);
+    public GetMemberInfoResponseDTO getMemberInfoForCreate() {
+        return teamService.GetMemberInfo();
     }
 
-/*
     @PostMapping("/create")
     @Operation(summary = "Create a new team")
-    public ResponseEntity<Team> createTeamsByContestAndMember(@RequestBody @Valid  CreateTeamRequestDTO createTeamRequestDTO) {
-        try {
-            Team team = teamService.createTeamsByContestAndMember(createTeamRequestDTO);
-            return ResponseEntity.ok(team);
-        } catch (Exception e) {
-            return ResponseEntity.status(500).body(null);
-        }
+    public Team createTeamsByContestAndMember(@RequestBody @Valid CreateTeamRequestDTO createTeamRequestDTO) {
+        return teamService.createTeamsByContestAndMember(createTeamRequestDTO);
     }
-*/
-
 
     @GetMapping("/apply")
     @Operation(summary = "팀 신청 기능에서 멤버 정보 조회", description = "팀원 신청서 작성 시 해당 멤버의 이름과 전화번호를 반환합니다.(자동완성기능)")
-    public ResponseEntity<GetMemberInfoResponseDTO> getMemberInfo() {
-        try {
-            GetMemberInfoResponseDTO response = teamService.GetMemberInfo();
-            return ResponseEntity.ok(response);
-        } catch (Exception e) {
-            return ResponseEntity.status(500).body(null);
-        }
+    public GetMemberInfoResponseDTO getMemberInfo() {
+        return teamService.GetMemberInfo();
     }
 
     @PostMapping("/apply")
     @Operation(summary = "팀 신청하기")
-    public ResponseEntity<TeamMatching> applyTeam(@RequestBody @Valid ApplyTeamRequestDTO applyTeamRequestDTO) {
-        try {
-            TeamMatching teamMatching = teamService.applyToTeam(applyTeamRequestDTO);
-            return ResponseEntity.ok(teamMatching);
-        } catch (Exception e) {
-            return ResponseEntity.status(500).body(null);
-        }
-
+    public TeamMatching applyTeam(@RequestBody @Valid ApplyTeamRequestDTO applyTeamRequestDTO) {
+        return teamService.applyToTeam(applyTeamRequestDTO);
     }
-
-
-
 }

--- a/src/main/java/com/example/devcrew/domain/team/entity/Team.java
+++ b/src/main/java/com/example/devcrew/domain/team/entity/Team.java
@@ -4,6 +4,7 @@ import com.example.devcrew.domain.contest.entity.Contest;
 import com.example.devcrew.domain.member.entity.Member;
 import com.example.devcrew.domain.member.entity.NormalMember;
 import com.example.devcrew.global.common.BaseTimeEntity;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -19,57 +20,7 @@ import java.util.List;
 @AllArgsConstructor
 public class Team extends BaseTimeEntity {
 
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-// **** Contest, NormalMember FK ****
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "contest_id", nullable = false)
-    private Contest contest;
-
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
-
-
-     @OneToMany(mappedBy = "team", fetch = FetchType.LAZY)
-     private List<TeamMatching> teamMatchingList = new ArrayList<>();
-
-
-    @Column(length = 30)
-    private String name;
-
-    @Column(length = 20)
-    private String password;
-
-    private Integer peopleNum;
-
-    @Column(length = 30)
-    private String serviceName;
-
-    @Column(length = 255)
-    private String planUrl;
-
-    //대상 기기 부분 삭제
-    //@Column(length = 30)
-   // private String formDevelop;
-
-    @Column(length = 50)
-    private String equipment;
-
-    @Enumerated(EnumType.STRING)
-    private Os os;
-
-
-}
-
-/*
-@JsonIgnore 을 사용하여 순환 참조 문제 해결
-
+    //*** @JsonIgnore 사용 ***
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -108,5 +59,50 @@ public class Team extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Os os;
 
+}
+/*
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
- */
+// **** Contest, NormalMember FK ****
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contest_id", nullable = false)
+    private Contest contest;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+     // 단방향 매핑 삭제 -> 스택오버플로우 문제는 여전함
+     //@OneToMany(mappedBy = "team", fetch = FetchType.LAZY)
+     //private List<TeamMatching> teamMatchingList = new ArrayList<>();
+
+
+    @Column(length = 30)
+    private String name;
+
+    @Column(length = 20)
+    private String password;
+
+    private Integer peopleNum;
+
+    @Column(length = 30)
+    private String serviceName;
+
+    @Column(length = 255)
+    private String planUrl;
+
+    //대상 기기 부분 삭제
+    //@Column(length = 30)
+   // private String formDevelop;
+
+    @Column(length = 50)
+    private String equipment;
+
+    @Enumerated(EnumType.STRING)
+    private Os os;
+
+*/

--- a/src/main/java/com/example/devcrew/domain/team/entity/TeamMatching.java
+++ b/src/main/java/com/example/devcrew/domain/team/entity/TeamMatching.java
@@ -2,6 +2,7 @@ package com.example.devcrew.domain.team.entity;
 
 import com.example.devcrew.domain.member.entity.Member;
 import com.example.devcrew.global.common.BaseTimeEntity;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -13,34 +14,7 @@ import lombok.*;
 @AllArgsConstructor
 public class TeamMatching extends BaseTimeEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-     @ManyToOne(fetch = FetchType.LAZY)
-     @JoinColumn(name = "team_id", nullable = false)
-     private Team team;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
-
-    /* 일반 회원 테이블과 N:1 매핑
-        @ManyToOne(fetch = FetchType.LAZY)
-        @Column(nullable = false)
-        private Member? normalMemberId;
-    */
-    @JoinColumn(name = "portfolio_url", nullable = false)
-    private String portfolioUrl;
-
-    @Enumerated(EnumType.STRING)
-    private Objective objective;
-
-}
-
-/*
-@JsonIgnore 을 사용하여 순환 참조 문제 해결
-
+    //*** @JsonIgnore 사용 ***
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -61,5 +35,23 @@ public class TeamMatching extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Objective objective;
 }
+/*
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
- */
+     @ManyToOne(fetch = FetchType.LAZY)
+     @JoinColumn(name = "team_id", nullable = false)
+     private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @JoinColumn(name = "portfolio_url", nullable = false)
+    private String portfolioUrl;
+
+    @Enumerated(EnumType.STRING)
+    private Objective objective;
+
+    */

--- a/src/main/java/com/example/devcrew/domain/team/service/TeamService.java
+++ b/src/main/java/com/example/devcrew/domain/team/service/TeamService.java
@@ -1,8 +1,12 @@
 package com.example.devcrew.domain.team.service;
 
+import com.example.devcrew.domain.contest.entity.Contest;
+import com.example.devcrew.domain.contest.exception.ContestNotFoundException;
+import com.example.devcrew.domain.contest.repository.ContestRepository;
 import com.example.devcrew.domain.member.entity.Member;
 import com.example.devcrew.domain.member.repository.MemberRepository;
 import com.example.devcrew.domain.team.dto.request.ApplyTeamRequestDTO;
+import com.example.devcrew.domain.team.dto.request.CreateTeamRequestDTO;
 import com.example.devcrew.domain.team.dto.response.GetMemberInfoResponseDTO;
 import com.example.devcrew.domain.team.entity.Team;
 import com.example.devcrew.domain.team.entity.TeamMatching;
@@ -22,16 +26,16 @@ public class TeamService {
     private final TeamRepository teamRepository;
     private final MemberRepository memberRepository;
     private final TeamMatchingRepository teamMatchingRepository;
-    //private final ContestRepository contestRepository;
+    private final ContestRepository contestRepository;
     private final AuthService authService;
 
-/*
+
     @Transactional
     public Team createTeamsByContestAndMember(CreateTeamRequestDTO request) {
 
         Contest contest = contestRepository.findById(request.getContestId())
                 //예외처리 추가된거로 수정하기
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 공모전입니다."));
+                .orElseThrow(ContestNotFoundException::new);
 
         Member member = authService.getLoginUser();
 
@@ -53,7 +57,7 @@ public class TeamService {
         return teamRepository.save(team);
     }
 
-*/
+
 
     @Transactional
     public GetMemberInfoResponseDTO GetMemberInfo() {

--- a/src/main/java/com/example/devcrew/domain/team/service/TeamService.java
+++ b/src/main/java/com/example/devcrew/domain/team/service/TeamService.java
@@ -15,9 +15,12 @@ import com.example.devcrew.domain.team.exception.TeamNotFoundException;
 import com.example.devcrew.domain.team.repository.TeamMatchingRepository;
 import com.example.devcrew.domain.team.repository.TeamRepository;
 import com.example.devcrew.domain.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Service
 @RequiredArgsConstructor
@@ -34,7 +37,6 @@ public class TeamService {
     public Team createTeamsByContestAndMember(CreateTeamRequestDTO request) {
 
         Contest contest = contestRepository.findById(request.getContestId())
-                //예외처리 추가된거로 수정하기
                 .orElseThrow(ContestNotFoundException::new);
 
         Member member = authService.getLoginUser();
@@ -57,34 +59,35 @@ public class TeamService {
         return teamRepository.save(team);
     }
 
-
-
     @Transactional
     public GetMemberInfoResponseDTO GetMemberInfo() {
         Member member = authService.getLoginUser();
         return new GetMemberInfoResponseDTO(member.getName(), member.getNormalMember().getPhoneNumber());
     }
 
-@Transactional
-public TeamMatching applyToTeam(ApplyTeamRequestDTO requestDTO) {
-    Team team = teamRepository.findById(requestDTO.getTeamId())
-            .orElseThrow(TeamNotFoundException::new);
+    @Transactional
+    public TeamMatching applyToTeam(ApplyTeamRequestDTO requestDTO) {
+        Team team = teamRepository.findById(requestDTO.getTeamId())
+                .orElseThrow(TeamNotFoundException::new);
 
-    if( !team.getPassword()
-            .equals(requestDTO.getTeamPassword()) ) {
-        throw new InvalidTeamPasswordException();
+        if( !team.getPassword()
+                .equals(requestDTO.getTeamPassword()) ) {
+            throw new InvalidTeamPasswordException();
+        }
+
+        Member member = authService.getLoginUser();
+
+
+        TeamMatching teamMatching = TeamMatching.builder()
+                .team(team)
+                .member(member)
+                .portfolioUrl(requestDTO.getPortfolioUrl())
+                .objective(requestDTO.getObjective())
+                .build();
+
+        return teamMatchingRepository.save(teamMatching);
     }
 
-    Member member = authService.getLoginUser();
 
 
-    TeamMatching teamMatching = TeamMatching.builder()
-            .team(team)
-            .member(member)
-            .portfolioUrl(requestDTO.getPortfolioUrl())
-            .objective(requestDTO.getObjective())
-            .build();
-
-    return teamMatchingRepository.save(teamMatching);
-}
 }


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- feat/#46-공모전-정보-조회-구현 

### ⚡️ 작업동기

- 팀 구성하기, 신청하기 페이지 상단 공모전 상세정보 조회 기능 구현

### 🔑 주요 변경사항

- 팀, 팀매칭 엔티티 간 순환 참조 문제 @JsonIgnore로 해결했습니다. 테스트 해보니 팀 구성 및 신청 기능에 영향은 없었습니다!

### 💡 관련 이슈

- #46 
