### PR TITLE
chore(#128): dockerfile 수정 - timezone 설정 for 로그

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ COPY build/libs/devcrew-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8080
 
 
-ENTRYPOINT ["java", "-jar", "app.jar", "--spring.config.location=classpath:/application.yml,classpath:/application-prod.yml"]
+ENTRYPOINT ["java", "-jar", "app.jar", "-Duser.timezone=Asia/Seoul",  "--spring.config.location=classpath:/application.yml,classpath:/application-prod.yml"]


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- #128 

### ⚡️ 작업동기

- 도커 로그 시간대가 한국이 아닌 문제 해결

### 🔑 주요 변경사항

- dockerfile의 timezone 설정 추가

### 💡 관련 이슈

- 관련 이슈를 입력해주세요.
